### PR TITLE
Persistent volume and user account

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,17 @@ RUN mkdir -p /home/mchorse/.ssh && \
     echo 'PasswordAuthentication yes' >> /etc/ssh/sshd_config && \
     echo 'export PDSH_RCMD_TYPE=ssh' >> /home/mchorse/.bashrc
 
+#### Python packages
+RUN python -m pip install --upgrade pip && \
+    pip install gpustat && \
+    pip install torch==1.7.1
+
+COPY requirements.txt $STAGE_DIR/mchorse
+RUN pip install -r $STAGE_DIR/requirements.txt
+RUN pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" git+https://github.com/NVIDIA/apex.git
+RUN echo 'deb http://archive.ubuntu.com/ubuntu/ focal main restricted' >> /etc/apt/sources.list && apt-get install --upgrade libpython3-dev
+RUN sudo apt-get update -y && sudo apt-get install -y libpython3-dev
+
 # Clear staging
 RUN rm -r $STAGE_DIR
 
@@ -58,14 +69,3 @@ RUN rm -r $STAGE_DIR
 USER mchorse
 WORKDIR /home/mchorse
 ENV PATH="/home/mchorse/.local/bin:${PATH}"
-
-#### Python packages
-RUN python -m pip install --upgrade pip && \
-    pip install gpustat && \
-    pip install torch==1.7.1
-
-COPY requirements.txt /home/mchorse
-RUN pip install -r /home/mchorse/requirements.txt
-RUN pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" git+https://github.com/NVIDIA/apex.git
-RUN echo 'deb http://archive.ubuntu.com/ubuntu/ focal main restricted' >> /etc/apt/sources.list && apt-get install --upgrade libpython3-dev
-RUN sudo apt-get update -y && sudo apt-get install -y libpython3-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN echo 'deb http://archive.ubuntu.com/ubuntu/ focal main restricted' >> /etc/a
 RUN sudo apt-get update -y && sudo apt-get install -y libpython3-dev
 
 # Clear staging
-RUN rm -r $STAGE_DIR && mkdir -m 0777 /tmp
+RUN rm -r $STAGE_DIR && mkdir -p /tmp && chmod 0777 /tmp
 
 #### SWITCH TO mchorse USER
 USER mchorse

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN echo 'deb http://archive.ubuntu.com/ubuntu/ focal main restricted' >> /etc/a
 RUN sudo apt-get update -y && sudo apt-get install -y libpython3-dev
 
 # Clear staging
-RUN rm -r $STAGE_DIR
+RUN rm -r $STAGE_DIR && mkdir -m 0777 /tmp
 
 #### SWITCH TO mchorse USER
 USER mchorse

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,15 +5,16 @@ RUN apt-get update -y && \
     update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1 && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1 && \
     useradd -ms /bin/bash mchorse
-USER mchorse
-WORKDIR /home/mchorse
 
-RUN mkdir -p ~/.ssh && \
-    echo 'Host *' > ~/.ssh/config && \
-    echo '    StrictHostKeyChecking no' >> ~/.ssh/config && \
+RUN mkdir -p /home/mchorse.ssh && \
+    echo 'Host *' > /home/mchorse.ssh/config && \
+    echo '    StrictHostKeyChecking no' >> /home/mchorse.ssh/config && \
     echo 'AuthorizedKeysFile     .ssh/authorized_keys' >> /etc/ssh/sshd_config && \
     echo 'PasswordAuthentication yes' >> /etc/ssh/sshd_config && \
-    echo 'export PDSH_RCMD_TYPE=ssh' >> ~/.bashrc
+    echo 'export PDSH_RCMD_TYPE=ssh' >> /home/mchorse.bashrc
+
+USER mchorse
+WORKDIR /home/mchorse
 
 RUN python3 -m pip install --upgrade pip && \
     pip3 install pipx gpustat && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,28 +2,27 @@ FROM atlanticcrypto/cuda-ssh-server:10.2-cudnn
 
 RUN apt-get update -y && \
     apt-get install -y git python3.8 python3.8-dev libpython3.8-dev libopenmpi-dev python3-pip python3-venv sudo pdsh htop llvm-9-dev cmake tmux zstd libpython3-dev && \
-    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1 && \
+    useradd -ms /bin/bash mchorse
+USER mchorse
+WORKDIR /home/mchorse
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1 && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1 && \
     python3 -m pip install --upgrade pip && \
     pip3 install pipx gpustat && \
     python3 -m pipx ensurepath
 
-RUN mkdir -p ~/.ssh /app /job /build_dir && \
+RUN mkdir -p ~/.ssh && \
     echo 'Host *' > ~/.ssh/config && \
     echo '    StrictHostKeyChecking no' >> ~/.ssh/config && \
     echo 'AuthorizedKeysFile     .ssh/authorized_keys' >> /etc/ssh/sshd_config && \
     echo 'PasswordAuthentication yes' >> /etc/ssh/sshd_config && \
     echo 'export PDSH_RCMD_TYPE=ssh' >> ~/.bashrc
 
-WORKDIR /build_dir
-
-COPY requirements.txt /build_dir
+COPY requirements.txt /home/mchorse
 RUN pip install torch==1.7.1
 RUN pip install --upgrade tensorflow
 RUN pip install -r requirements.txt
 RUN pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" git+https://github.com/NVIDIA/apex.git
 RUN echo 'deb http://archive.ubuntu.com/ubuntu/ focal main restricted' >> /etc/apt/sources.list && apt-get install --upgrade libpython3-dev
 RUN sudo apt-get update -y && sudo apt-get install -y libpython3-dev
-
-WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,7 @@ RUN rm -r $STAGE_DIR
 
 #### SWITCH TO mchorse USER
 USER mchorse
+WORKDIR /home/mchorse
 ENV PATH="/home/mchorse/.local/bin:${PATH}"
 
 #### Python packages
@@ -64,7 +65,7 @@ RUN python -m pip install --upgrade pip && \
     pip install torch==1.7.1
 
 COPY requirements.txt /home/mchorse
-RUN pip install -r requirements.txt
+RUN pip install -r /home/mchorse/requirements.txt
 RUN pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" git+https://github.com/NVIDIA/apex.git
 RUN echo 'deb http://archive.ubuntu.com/ubuntu/ focal main restricted' >> /etc/apt/sources.list && apt-get install --upgrade libpython3-dev
 RUN sudo apt-get update -y && sudo apt-get install -y libpython3-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,11 @@ FROM atlanticcrypto/cuda-ssh-server:10.2-cudnn
 
 RUN apt-get update -y && \
     apt-get install -y git python3.8 python3.8-dev libpython3.8-dev libopenmpi-dev python3-pip python3-venv sudo pdsh htop llvm-9-dev cmake tmux zstd libpython3-dev && \
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1 && \
+    update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1 && \
     useradd -ms /bin/bash mchorse
 USER mchorse
 WORKDIR /home/mchorse
-RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1 && \
-    update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1 && \
-    python3 -m pip install --upgrade pip && \
-    pip3 install pipx gpustat && \
-    python3 -m pipx ensurepath
 
 RUN mkdir -p ~/.ssh && \
     echo 'Host *' > ~/.ssh/config && \
@@ -18,9 +15,13 @@ RUN mkdir -p ~/.ssh && \
     echo 'PasswordAuthentication yes' >> /etc/ssh/sshd_config && \
     echo 'export PDSH_RCMD_TYPE=ssh' >> ~/.bashrc
 
+RUN python3 -m pip install --upgrade pip && \
+    pip3 install pipx gpustat && \
+    python3 -m pipx ensurepath && \
+    pip install torch==1.7.1 && \
+    pip install --upgrade tensorflow
+
 COPY requirements.txt /home/mchorse
-RUN pip install torch==1.7.1
-RUN pip install --upgrade tensorflow
 RUN pip install -r requirements.txt
 RUN pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" git+https://github.com/NVIDIA/apex.git
 RUN echo 'deb http://archive.ubuntu.com/ubuntu/ focal main restricted' >> /etc/apt/sources.list && apt-get install --upgrade libpython3-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,67 @@
 FROM atlanticcrypto/cuda-ssh-server:10.2-cudnn
 
+#### System package
 RUN apt-get update -y && \
-    apt-get install -y git python3.8 python3.8-dev libpython3.8-dev libopenmpi-dev python3-pip python3-venv sudo pdsh htop llvm-9-dev cmake tmux zstd libpython3-dev && \
+    apt-get install -y \
+        git python3.8 python3.8-dev libpython3.8-dev  python3-pip python3-venv sudo pdsh \
+        htop llvm-9-dev tmux zstd libpython3-dev software-properties-common build-essential autotools-dev \
+        nfs-common pdsh cmake g++ gcc curl wget tmux less unzip htop iftop iotop ca-certificates \
+        rsync iputils-ping net-tools llvm-9-dev libcupti-dev && \
     update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1 && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1 && \
-    useradd -ms /bin/bash mchorse
+    update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 
-RUN mkdir -p /home/mchorse.ssh && \
-    echo 'Host *' > /home/mchorse.ssh/config && \
-    echo '    StrictHostKeyChecking no' >> /home/mchorse.ssh/config && \
+ENV DEBIAN_FRONTEND=noninteractive
+
+#### Temporary Installation Directory
+ENV STAGE_DIR=/tmp
+RUN mkdir -p ${STAGE_DIR}
+
+#### OPENMPI
+ENV OPENMPI_BASEVERSION=4.0
+ENV OPENMPI_VERSION=${OPENMPI_BASEVERSION}.1
+RUN cd ${STAGE_DIR} && \
+    wget -q -O - https://download.open-mpi.org/release/open-mpi/v${OPENMPI_BASEVERSION}/openmpi-${OPENMPI_VERSION}.tar.gz | tar xzf - && \
+    cd openmpi-${OPENMPI_VERSION} && \
+    ./configure --prefix=/usr/local/openmpi-${OPENMPI_VERSION} && \
+    make -j"$(nproc)" install && \
+    ln -s /usr/local/openmpi-${OPENMPI_VERSION} /usr/local/mpi && \
+    # Sanity check:
+    test -f /usr/local/mpi/bin/mpic++ && \
+    cd ${STAGE_DIR} && \
+    rm -r ${STAGE_DIR}/openmpi-${OPENMPI_VERSION}
+ENV PATH=/usr/local/mpi/bin:${PATH} \
+    LD_LIBRARY_PATH=/usr/local/lib:/usr/local/mpi/lib:/usr/local/mpi/lib64:${LD_LIBRARY_PATH}
+# Create a wrapper for OpenMPI to allow running as root by default
+RUN mv /usr/local/mpi/bin/mpirun /usr/local/mpi/bin/mpirun.real && \
+    echo '#!/bin/bash' > /usr/local/mpi/bin/mpirun && \
+    echo 'mpirun.real --allow-run-as-root --prefix /usr/local/mpi "$@"' >> /usr/local/mpi/bin/mpirun && \
+    chmod a+x /usr/local/mpi/bin/mpirun
+
+#### User account
+RUN useradd --create-home --uid 1000 --shell /bin/bash mchorse && \
+    usermod -aG sudo mchorse && \
+    echo "mchorse ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+## SSH config
+RUN mkdir -p /home/mchorse/.ssh && \
+    echo 'Host *' > /home/mchorse/.ssh/config && \
+    echo '    StrictHostKeyChecking no' >> /home/mchorse/.ssh/config && \
     echo 'AuthorizedKeysFile     .ssh/authorized_keys' >> /etc/ssh/sshd_config && \
     echo 'PasswordAuthentication yes' >> /etc/ssh/sshd_config && \
-    echo 'export PDSH_RCMD_TYPE=ssh' >> /home/mchorse.bashrc
+    echo 'export PDSH_RCMD_TYPE=ssh' >> /home/mchorse/.bashrc
 
+#### SWITCH TO mchorse USER
 USER mchorse
-WORKDIR /home/mchorse
 ENV PATH="/home/mchorse/.local/bin:${PATH}"
 
-RUN python3 -m pip install --upgrade pip && \
-    pip3 install pipx gpustat && \
-    python3 -m pipx ensurepath && \
-    pip3 install torch==1.7.1 && \
-    pip3 install --upgrade tensorflow
+#### Python packages
+RUN python -m pip install --upgrade pip && \
+    pip install gpustat && \
+    pip install torch==1.7.1
 
 COPY requirements.txt /home/mchorse
-RUN pip3 install -r requirements.txt
-RUN pip3 install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" git+https://github.com/NVIDIA/apex.git
+RUN pip install -r requirements.txt
+RUN pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" git+https://github.com/NVIDIA/apex.git
 RUN echo 'deb http://archive.ubuntu.com/ubuntu/ focal main restricted' >> /etc/apt/sources.list && apt-get install --upgrade libpython3-dev
 RUN sudo apt-get update -y && sudo apt-get install -y libpython3-dev
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,5 +68,4 @@ RUN rm -r $STAGE_DIR
 #### SWITCH TO mchorse USER
 USER mchorse
 WORKDIR /home/mchorse
-RUN sudo chown mchorse /job
 ENV PATH="/home/mchorse/.local/bin:${PATH}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN python -m pip install --upgrade pip && \
     pip install gpustat && \
     pip install torch==1.7.1
 
-COPY requirements.txt $STAGE_DIR/mchorse
+COPY requirements.txt $STAGE_DIR
 RUN pip install -r $STAGE_DIR/requirements.txt
 RUN pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" git+https://github.com/NVIDIA/apex.git
 RUN echo 'deb http://archive.ubuntu.com/ubuntu/ focal main restricted' >> /etc/apt/sources.list && apt-get install --upgrade libpython3-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,12 +15,13 @@ RUN mkdir -p /home/mchorse.ssh && \
 
 USER mchorse
 WORKDIR /home/mchorse
+ENV PATH="/home/mchorse/.local/bin:${PATH}"
 
 RUN python3 -m pip install --upgrade pip && \
     pip3 install pipx gpustat && \
     python3 -m pipx ensurepath && \
-    pip install torch==1.7.1 && \
-    pip install --upgrade tensorflow
+    pip3 install torch==1.7.1 && \
+    pip3 install --upgrade tensorflow
 
 COPY requirements.txt /home/mchorse
 RUN pip3 install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,9 @@ RUN mkdir -p /home/mchorse/.ssh && \
     echo 'PasswordAuthentication yes' >> /etc/ssh/sshd_config && \
     echo 'export PDSH_RCMD_TYPE=ssh' >> /home/mchorse/.bashrc
 
+# Clear staging
+RUN rm -r $STAGE_DIR/*
+
 #### SWITCH TO mchorse USER
 USER mchorse
 ENV PATH="/home/mchorse/.local/bin:${PATH}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN mkdir -p /home/mchorse/.ssh && \
     echo 'export PDSH_RCMD_TYPE=ssh' >> /home/mchorse/.bashrc
 
 # Clear staging
-RUN rm -r $STAGE_DIR/*
+RUN rm -r $STAGE_DIR
 
 #### SWITCH TO mchorse USER
 USER mchorse

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update -y && \
 ENV DEBIAN_FRONTEND=noninteractive
 
 #### Temporary Installation Directory
-ENV STAGE_DIR=/tmp
+ENV STAGE_DIR=/build
 RUN mkdir -p ${STAGE_DIR}
 
 #### OPENMPI
@@ -44,7 +44,7 @@ RUN useradd --create-home --uid 1000 --shell /bin/bash mchorse && \
     echo "mchorse ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
 ## SSH config
-RUN mkdir -p /home/mchorse/.ssh && \
+RUN mkdir -p /home/mchorse/.ssh /job && \
     echo 'Host *' > /home/mchorse/.ssh/config && \
     echo '    StrictHostKeyChecking no' >> /home/mchorse/.ssh/config && \
     echo 'AuthorizedKeysFile     .ssh/authorized_keys' >> /etc/ssh/sshd_config && \
@@ -68,4 +68,5 @@ RUN rm -r $STAGE_DIR
 #### SWITCH TO mchorse USER
 USER mchorse
 WORKDIR /home/mchorse
+RUN sudo chown mchorse /job
 ENV PATH="/home/mchorse/.local/bin:${PATH}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN python3 -m pip install --upgrade pip && \
     pip install --upgrade tensorflow
 
 COPY requirements.txt /home/mchorse
-RUN pip install -r requirements.txt
-RUN pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" git+https://github.com/NVIDIA/apex.git
+RUN pip3 install -r requirements.txt
+RUN pip3 install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" git+https://github.com/NVIDIA/apex.git
 RUN echo 'deb http://archive.ubuntu.com/ubuntu/ focal main restricted' >> /etc/apt/sources.list && apt-get install --upgrade libpython3-dev
 RUN sudo apt-get update -y && sudo apt-get install -y libpython3-dev
 

--- a/examples/ds_pretrain_gpt2_medium_pipe.sh
+++ b/examples/ds_pretrain_gpt2_medium_pipe.sh
@@ -12,9 +12,9 @@ export DLWS_NUM_GPU_PER_WORKER=${GPUS_PER_NODE}
 
 # DATA OPTIONS: 
 
-DATA_PATH=data/enron/enron_text_document
-VOCAB_PATH=data/gpt2-vocab.json
-MERGE_PATH=data/gpt2-merges.txt
+DATA_PATH=$DATA_DIR/enron/enron_text_document
+VOCAB_PATH=$DATA_DIR/gpt2-vocab.json
+MERGE_PATH=$DATA_DIR/gpt2-merges.txt
 CHECKPOINT_PATH=checkpoints/gpt2_345m_ds
 
 script_path=$(realpath $0)

--- a/examples/ds_pretrain_gpt2_medium_pipe.sh
+++ b/examples/ds_pretrain_gpt2_medium_pipe.sh
@@ -147,7 +147,7 @@ chkp_opt="${chkp_opt} \
 fi
 
 full_options="${gpt_options} ${deepspeed_options} ${chkp_opt}"
-
+#/home/mchorse/megatron-3d/deepy.py
 run_cmd="deepspeed pretrain_gpt2.py $@ ${full_options}"
 echo ${run_cmd}
 eval ${run_cmd}

--- a/kubernetes/deploy_data_writer.sh
+++ b/kubernetes/deploy_data_writer.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+#  --- USAGE ---
+# $ deploy_data_writer.sh [branch] [image]
+# You need to install yq
+
+# Check yq
+yq &> /dev/null || { echo 'You need to install `yq >= v4`. `brew install yq` or `pip install yq`' ; exit 1; }
+
+DEFAULT_IMAGE="leogao2/megatron-3d:sha-e0abd42"
+
+BRANCH=${1:-main}
+IMAGE=${4:-$DEFAULT_IMAGE}
+
+DEPLOYMENT_NM='megatron-data-writer'
+WD=`dirname "$BASH_SOURCE"`
+
+echo DEPLOYMENT NAME $DEPLOYMENT_NM. BRANCH $BRANCH. DOCKER IMAGE $IMAGE.
+
+post_start_script="
+echo 'export DATA_DIR=/mnt/ssd-0/megatron-3d/data' >> /home/mchorse/.bashrc;
+git clone --branch $BRANCH https://github.com/EleutherAI/megatron-3d.git;
+"
+echo $post_start_script > $WD/post_start_script_dw.sh
+
+# Add ssh key to k8 secrets and post start script
+DATE=$(date +%s)
+SECRET_NM="$DEPLOYMENT_NM-$DATE"
+kubectl create secret generic $SECRET_NM \
+  --from-file=post_start_script.sh=$WD/post_start_script_dw.sh
+
+# Template k8 configuration
+cat $WD/k8s_spec_data_writer.yml |
+yq e '.metadata.name = "'"$DEPLOYMENT_NM"\" - |
+yq e '.spec.template.spec.volumes[1].secret.secretName = "'"$SECRET_NM"\" - |
+yq e '.spec.template.spec.containers[0].image = "'"$IMAGE"\" - > $WD/k8s_spec_data_writer_temp.yml
+
+# Delete previous and setup deployment
+kubectl delete deploy/$DEPLOYMENT_NM || { echo 'No previous deployment'; }
+kubectl apply -f $WD/k8s_spec_data_writer_temp.yml
+
+echo Waiting for deploy to complete...
+kubectl wait --for=condition=available --timeout=600s deployment/$DEPLOYMENT_NM || { echo 'Deployment failed' ; exit 1; }
+
+export MAIN_ID=$(kubectl get pods | grep $DEPLOYMENT_NM | awk '{print $1}' | head -n 1)
+
+rm $WD/k8s_spec_data_writer_temp.yml $WD/post_start_script_dw.sh
+
+echo Remote shell into main $MAIN_ID
+kubectl exec --stdin --tty $MAIN_ID -- /bin/bash

--- a/kubernetes/deploy_data_writer.sh
+++ b/kubernetes/deploy_data_writer.sh
@@ -7,7 +7,7 @@
 # Check yq
 yq &> /dev/null || { echo 'You need to install `yq >= v4`. `brew install yq` or `pip install yq`' ; exit 1; }
 
-DEFAULT_IMAGE="leogao2/megatron-3d:sha-e0abd42"
+DEFAULT_IMAGE="leogao2/megatron-3d:sha-b8f5852"
 
 BRANCH=${1:-main}
 IMAGE=${4:-$DEFAULT_IMAGE}

--- a/kubernetes/deploy_k8s.sh
+++ b/kubernetes/deploy_k8s.sh
@@ -35,15 +35,17 @@ ssh-keygen -t rsa -f $WD/id_rsa -N ""
 
 post_start_script="
 echo 'export DATA_DIR=/mnt/ssd-0/megatron-3d/data' >> /home/mchorse/.bashrc;
-sudo chown mchorse /secrets/id_rsa.pub;
-cp /secrets/id_rsa.pub /home/mchorse/.ssh/authorized_keys;
+sudo cp /secrets/id_rsa.pub /home/mchorse/.ssh/authorized_keys;
+sudo chown mchorse:mchorse /home/mchorse/.ssh/authorized_keys;
+sudo chown -R mchorse:mchorse /home/mchorse/.ssh;
 chmod 600 /home/mchorse/.ssh/authorized_keys;
 chmod 700 /home/mchorse/.ssh;
-chown -R mchorse /home/mchorse/.ssh;
 cd /home/mchorse;
 git clone --branch $BRANCH https://github.com/EleutherAI/megatron-3d.git;
 apt-get update -y;
 apt-get install -y libpython3-dev;
+sudo mkdir /job;
+sudo chown mchorse:mchorse /job;
 "
 if [ -n "$WANDB_APIKEY" ]
 then

--- a/kubernetes/deploy_k8s.sh
+++ b/kubernetes/deploy_k8s.sh
@@ -41,15 +41,13 @@ rm $WD/id_rsa*
 ssh-keygen -t rsa -f $WD/id_rsa -N "" 
 
 post_start_script="
-cp /secrets/id_rsa.pub /root/.ssh/authorized_keys;
-chmod 600 /root/.ssh/authorized_keys;
-chmod 700 /root/.ssh;
-chown -R root /root/.ssh;
-rm -r /app/*;
-cd /app;
-git clone https://github.com/EleutherAI/megatron-3d.git .;
+cp /secrets/id_rsa.pub /home/mchorse/.ssh/authorized_keys;
+chmod 600 /home/mchorse/.ssh/authorized_keys;
+chmod 700 /home/mchorse/.ssh;
+chown -R root /home/mchorse/.ssh;
+cd /home/mchorse;
+git clone --single-branch --branch $BRANCH https://github.com/EleutherAI/megatron-3d.git;
 cd megatron-3d;
-git checkout $BRANCH;
 apt-get update -y;
 apt-get install -y libpython3-dev
 "

--- a/kubernetes/deploy_k8s.sh
+++ b/kubernetes/deploy_k8s.sh
@@ -34,7 +34,7 @@ rm $WD/id_rsa*
 ssh-keygen -t rsa -f $WD/id_rsa -N "" 
 
 post_start_script="
-echo 'export DATA_DIR=/mnt/ssd-0/megatron-3d/data' >> /home/mchorse/.bashrc;
+echo 'export DATA_DIR=/mnt/ssd-cluster/data' >> /home/mchorse/.bashrc;
 sudo cp /secrets/id_rsa.pub /home/mchorse/.ssh/authorized_keys;
 sudo chown mchorse:mchorse /home/mchorse/.ssh/authorized_keys;
 sudo chown -R mchorse:mchorse /home/mchorse/.ssh;

--- a/kubernetes/deploy_k8s.sh
+++ b/kubernetes/deploy_k8s.sh
@@ -4,8 +4,6 @@
 # $ deploy_k8.sh [branch=main] [n_nodes=4] [name_suffix=$USER] [image]
 # You need to install yq
 
-set -x
-
 # Check yq
 yq &> /dev/null || { echo 'You need to install `yq >= v4`. `brew install yq` or `pip install yq`' ; exit 1; }
 
@@ -41,6 +39,7 @@ rm $WD/id_rsa*
 ssh-keygen -t rsa -f $WD/id_rsa -N "" 
 
 post_start_script="
+echo 'export DATA_DIR=/mnt/ssd-0/megatron-3d/data' >> /home/mchorse/.bashrc;
 cp /secrets/id_rsa.pub /home/mchorse/.ssh/authorized_keys;
 chmod 600 /home/mchorse/.ssh/authorized_keys;
 chmod 700 /home/mchorse/.ssh;
@@ -66,7 +65,7 @@ kubectl create secret generic $SECRET_NM \
   --from-file=post_start_script.sh=$WD/post_start_script.sh
 
 # Template k8 configuration
-cat $WD/k8s_spec.yml |
+cat $WD/k8s_spec_with_mnt.yml |
 yq e '.metadata.name = "'"$DEPLOYMENT_NM"\" - |
 yq e '.spec.replicas = '"$N_NODES" - |
 yq e '.spec.template.spec.volumes[1].secret.secretName = "'"$SECRET_NM"\" - |

--- a/kubernetes/deploy_k8s.sh
+++ b/kubernetes/deploy_k8s.sh
@@ -9,7 +9,7 @@ yq &> /dev/null || { echo 'You need to install `yq >= v4`. `brew install yq` or 
 
 WD_BRANCH=$(git branch  --no-color --show-current)
 WD_BRANCH="${WD_BRANCH/\//-}"  # remove forward slashes and replace with underscore
-DEFAULT_IMAGE="leogao2/megatron-3d:sha-e0abd42"
+DEFAULT_IMAGE="leogao2/megatron-3d:sha-b8f5852"
 
 BRANCH=${1:-main}
 N_NODES=${2:-4}
@@ -34,7 +34,6 @@ rm $WD/id_rsa*
 ssh-keygen -t rsa -f $WD/id_rsa -N "" 
 
 post_start_script="
-mkdir -m 0777 /tmp;
 echo 'export DATA_DIR=/mnt/ssd-0/megatron-3d/data' >> /home/mchorse/.bashrc;
 sudo cp /secrets/id_rsa.pub /home/mchorse/.ssh/authorized_keys;
 sudo chown mchorse:mchorse /home/mchorse/.ssh/authorized_keys;

--- a/kubernetes/deploy_k8s.sh
+++ b/kubernetes/deploy_k8s.sh
@@ -9,7 +9,7 @@ yq &> /dev/null || { echo 'You need to install `yq >= v4`. `brew install yq` or 
 
 WD_BRANCH=$(git branch  --no-color --show-current)
 WD_BRANCH="${WD_BRANCH/\//-}"  # remove forward slashes and replace with underscore
-DEFAULT_IMAGE="leogao2/megatron-3d:sha-cf2aca3"
+DEFAULT_IMAGE="leogao2/megatron-3d:sha-e0abd42"
 
 BRANCH=${1:-main}
 N_NODES=${2:-4}
@@ -35,17 +35,13 @@ ssh-keygen -t rsa -f $WD/id_rsa -N ""
 
 post_start_script="
 echo 'export DATA_DIR=/mnt/ssd-0/megatron-3d/data' >> /home/mchorse/.bashrc;
-
 sudo chown mchorse /secrets/id_rsa.pub;
 cp /secrets/id_rsa.pub /home/mchorse/.ssh/authorized_keys;
 chmod 600 /home/mchorse/.ssh/authorized_keys;
 chmod 700 /home/mchorse/.ssh;
 chown -R mchorse /home/mchorse/.ssh;
-
 cd /home/mchorse;
 git clone --branch $BRANCH https://github.com/EleutherAI/megatron-3d.git;
-cd megatron-3d;
-
 apt-get update -y;
 apt-get install -y libpython3-dev;
 "
@@ -86,7 +82,7 @@ echo Copying ssh key and host file to main node:
 echo $MAIN_ID
 kubectl cp $WD/hostfile $MAIN_ID:/job
 kubectl cp $WD/hosts $MAIN_ID:/job
-kubectl cp $WD/id_rsa $MAIN_ID:/root/.ssh
+kubectl cp $WD/id_rsa $MAIN_ID:/home/mchorse/.ssh
 
 rm $WD/id_rsa* $WD/hostfile $WD/hosts $WD/k8s_spec_temp.yml $WD/post_start_script.sh
 

--- a/kubernetes/deploy_k8s.sh
+++ b/kubernetes/deploy_k8s.sh
@@ -34,6 +34,7 @@ rm $WD/id_rsa*
 ssh-keygen -t rsa -f $WD/id_rsa -N "" 
 
 post_start_script="
+mkdir -m 0777 /tmp;
 echo 'export DATA_DIR=/mnt/ssd-0/megatron-3d/data' >> /home/mchorse/.bashrc;
 sudo cp /secrets/id_rsa.pub /home/mchorse/.ssh/authorized_keys;
 sudo chown mchorse:mchorse /home/mchorse/.ssh/authorized_keys;

--- a/kubernetes/k8_spec_ssd-0.yaml
+++ b/kubernetes/k8_spec_ssd-0.yaml
@@ -1,0 +1,13 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: eleuther-ssd-0
+  namespace: tenant-eleutherai
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 500Gi
+  storageClassName: sharedfs-ssd-replicated
+  volumeMode: Filesystem

--- a/kubernetes/k8_spec_ssd-cluster.yml
+++ b/kubernetes/k8_spec_ssd-cluster.yml
@@ -1,0 +1,13 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: eleuther-ssd-0
+  namespace: tenant-eleutherai
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 50Gi
+  storageClassName: sharedfs-ssd-replicated
+  volumeMode: Filesystem

--- a/kubernetes/k8s_spec.yml
+++ b/kubernetes/k8s_spec.yml
@@ -34,6 +34,9 @@ spec:
           - name: data-storage
             mountPath: /mnt/ssd-0
             readOnly: true
+          - name: cluster-storage
+            mountPath: /mnt/ssd-cluster
+            readOnly: false
         resources:
           requests:
             cpu: 30
@@ -71,4 +74,8 @@ spec:
           persistentVolumeClaim:
             claimName: eleuther-ssd-0
             readOnly: true
+        - name: cluster-storage
+          persistentVolumeClaim:
+            claimName: eleuther-ssd-cluster
+            readOnly: false
       restartPolicy: Always

--- a/kubernetes/k8s_spec.yml
+++ b/kubernetes/k8s_spec.yml
@@ -17,8 +17,8 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: neox
-        command: ["/usr/sbin/sshd"]
-        args: ["-D"]
+        command: ["sudo"]
+        args: ["/usr/sbin/sshd", "-D"]
         tty: true
         image: leogao2/megatron-3d
         ports:

--- a/kubernetes/k8s_spec.yml
+++ b/kubernetes/k8s_spec.yml
@@ -63,5 +63,5 @@ spec:
         - name: secret-volume
           secret:
             secretName: ----secret-name----
-            defaultMode: 0600
+            defaultMode: 0777
       restartPolicy: Always

--- a/kubernetes/k8s_spec_data_writer.yml
+++ b/kubernetes/k8s_spec_data_writer.yml
@@ -1,11 +1,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: eleuther-megatron
+  name: megatron-data-writer
 spec:
   strategy:
     type: Recreate
-  replicas: 4
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: eleuther-megatron
@@ -16,9 +16,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 10
       containers:
-      - name: neox
-        command: ["sudo"]
-        args: ["/usr/sbin/sshd", "-D"]
+      - name: data-writer
         tty: true
         image: leogao2/megatron-3d
         ports:
@@ -33,32 +31,16 @@ spec:
             mountPath: "/secrets"
           - name: data-storage
             mountPath: /mnt/ssd-0
-            readOnly: true
+            readOnly: false
         resources:
           requests:
             cpu: 30
-            memory: 40Gi
-          limits:
-            nvidia.com/gpu: 8
+            memory: 10Gi
         lifecycle:
           postStart:
             exec:
               command: [ "/bin/bash", "/secrets/post_start_script.sh" ]
 
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              # Edit for different GPU
-              - key: gpu.nvidia.com/model
-                operator: In
-                values:
-                  - GeForce_RTX_2080_Ti
-              - key: failure-domain.beta.kubernetes.io/region
-                operator: In
-                values:
-                  - ORD1
       volumes:
         - name: dshm
           emptyDir:
@@ -70,5 +52,4 @@ spec:
         - name: data-storage
           persistentVolumeClaim:
             claimName: eleuther-ssd-0
-            readOnly: true
       restartPolicy: Always

--- a/kubernetes/kill_k8s.sh
+++ b/kubernetes/kill_k8s.sh
@@ -5,5 +5,7 @@
 
 SUFFIX=${1:-$(whoami)}
 DEPLOYMENT_NM='megatron-'"$SUFFIX"
+MOUNT_NAME="$DEPLOYMENT_NM-ssd-cluster"
 
 kubectl delete deploy/$DEPLOYMENT_NM
+kubectl delete persistentvolumeclaims/$MOUNT_NAME

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ six
 regex
 numpy
 nltk
+tensorflow
 -e git+git://github.com/EleutherAI/DeeperSpeed.git@5a454114886709987a954ed315bf9f6b14cc4efc#egg=deepspeed
 autopep8
 zstandard

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
-pybind11
-torch
+pybind11==2.6.2
+torch==1.7.1
 six
 regex
-numpy
-nltk
-tensorflow
+numpy==1.19.5
+nltk==3.5
+tensorflow==2.4.1
 -e git+git://github.com/EleutherAI/DeeperSpeed.git@5a454114886709987a954ed315bf9f6b14cc4efc#egg=deepspeed
-autopep8
-zstandard
-cupy-cuda102
-mpi4py
-wandb
+autopep8==1.5.5
+zstandard==0.15.1
+cupy-cuda102==8.4.0
+mpi4py==3.0.3
+wandb==0.10.18

--- a/tools/corpora.py
+++ b/tools/corpora.py
@@ -15,9 +15,11 @@ When done, add it to the DATA_DOWNLOADERS dict. The function process_data runs t
 dataset.
 """
 
-GPT2_VOCAB_FP = "data/gpt2-vocab.json"
+DATA_DIR = os.environ.get('DATA_DIR', './data')
+
+GPT2_VOCAB_FP = f"{DATA_DIR}/gpt2-vocab.json"
 GPT2_VOCAB_URL = "https://s3.amazonaws.com/models.huggingface.co/bert/gpt2-vocab.json"
-GPT2_MERGE_FP = "data/gpt2-merges.txt"
+GPT2_MERGE_FP = f"{DATA_DIR}/gpt2-merges.txt"
 GPT2_MERGE_URL = "https://s3.amazonaws.com/models.huggingface.co/bert/gpt2-merges.txt"
 
 class DataDownloader(ABC):
@@ -26,7 +28,7 @@ class DataDownloader(ABC):
     @property
     def base_dir(self):
         """base data directory"""
-        return "./data"
+        return DATA_DIR
 
     @property
     @abstractmethod
@@ -124,7 +126,7 @@ DATA_DOWNLOADERS = {
 }
 
 def prepare_dataset(dataset_name):
-    os.makedirs('data', exist_ok=True)
+    os.makedirs(DATA_DIR, exist_ok=True)
     maybe_download_gpt2_tokenizer_data()
     DownloaderClass = DATA_DOWNLOADERS.get(dataset_name, None)
     if DownloaderClass is None:


### PR DESCRIPTION
- [x] user account
- [x] persistent volume
- [x] openmpi

* Installed openmpi (taken from deepseed image)
* Added a user account `mchorse` to docker container so that openmpi could run properly
* Deployed persistent volume with spec `k8_spec_ssd-0.yaml`
* Created a deploy script for a `data-writer`. The idea being that if you want to change the data on the PV you should startup this node. Otherwise all other nodes have read only access. This prevents different runs interfering with each other and producing weird side effects 
* Created an enviroment variable `DATA_DIR` that the prepare data script uses to put the data. I want to change the examples scripts to also use the `DATA_DIR`
* Pinned python requirements so that we don't get stung in the future